### PR TITLE
Fix: authorize hook broken — cb.true typo and async race

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -93,15 +93,13 @@ exports.expressConfigure = (hookName, args, cb) => {
 // FIRST STEP
 exports.authorize = (hookName, args, cb) => {
   // Never lands here for url /auth/callback
-  if (args.req.url.indexOf('/auth') === 0) return cb.true;
+  if (args.req.url.indexOf('/auth') === 0) return cb([true]);
 
-  let userIsAuthedAlready = false;
   console.debug(`Database lookup -> oauth:${args.req.sessionID}`);
   db.get(`oauth:${args.req.sessionID}`, (k, user) => {
     console.debug(`Oauth session found ->${args.req.sessionID}`, 'has user data of ', user);
-    if (user) userIsAuthedAlready = true;
+    return cb([!!user]);
   });
-  return cb([userIsAuthedAlready]);
 };
 
 // SECOND STEP

--- a/static/tests/backend/specs/authorize.ts
+++ b/static/tests/backend/specs/authorize.ts
@@ -1,0 +1,38 @@
+'use strict';
+
+import {strict as assert} from 'assert';
+import {init} from 'ep_etherpad-lite/tests/backend/common';
+import {generateJWTToken} from 'ep_etherpad-lite/tests/backend/common';
+
+let agent: any;
+
+describe('ep_oauth authorize hook', () => {
+  before(async () => {
+    agent = await init();
+  });
+
+  it('allows access to /auth paths without authentication', async () => {
+    // The authorize hook should return true for /auth/* paths,
+    // allowing the OAuth flow to proceed without prior auth.
+    // We test this by verifying the server doesn't reject /auth/callback
+    // with a 401 (it will 302 or handle it via the OAuth flow).
+    const res = await agent
+      .get('/auth/callback')
+      .set('Authorization', await generateJWTToken())
+      .redirects(0);
+    // Should not be 401 (unauthorized) — the authorize hook allows /auth paths
+    assert.notStrictEqual(res.status, 401);
+  });
+
+  it('rejects unauthenticated requests to pad paths', async () => {
+    // Without an OAuth session, accessing a pad should not be authorized.
+    // The exact behavior depends on etherpad config, but we verify the
+    // authorize hook is being called (server doesn't crash).
+    const res = await agent
+      .get('/p/test-oauth-pad')
+      .redirects(0);
+    // Should get some response (redirect to auth, or 200/302) but not crash
+    assert.ok([200, 302, 401, 403].includes(res.status),
+      `Expected 200/302/401/403, got ${res.status}`);
+  });
+});


### PR DESCRIPTION
## Summary

Two critical bugs in the `authorize` hook:

1. **`cb.true`** — accesses a non-existent property on the callback function, returning `undefined` instead of `[true]`. OAuth auth paths (`/auth/*`) were never properly authorized.

2. **Async race** — `db.get()` is async but `cb([userIsAuthedAlready])` ran synchronously before the database callback, so `userIsAuthedAlready` was always `false`. Authorization always failed for returning users.

## Fix

- `cb.true` → `cb([true])`
- Move `cb()` call inside `db.get()` callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)