### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_oauth
+# OAuth2 Authentication for Etherpad
 
 OAuth2 authentication for Etherpad via GitHub.
 


### PR DESCRIPTION
Replace the placeholder `ep_oauth` heading in README.md with "OAuth2 Authentication for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.